### PR TITLE
Add support for links in the text

### DIFF
--- a/app/components/editor/Editor.tsx
+++ b/app/components/editor/Editor.tsx
@@ -25,6 +25,7 @@ import { ReactElement, useState } from 'react';
 import { InlineTableInputNode } from './custom-nodes';
 import {
   ComponentPickerPlugin,
+  LinksPlugin,
   TableActionMenuPlugin,
   TableHoverActionsPlugin,
 } from './custom-plugins';
@@ -104,6 +105,7 @@ export default function Editor({
             onChange={onEditorStateChange}
             ignoreSelectionChange={true}
           />
+          <LinksPlugin/>
           {/* Add the table-related plugins with the anchor element */}
           {floatingAnchorElem && (
             <>

--- a/app/components/editor/custom-plugins/LinksPlugin.tsx
+++ b/app/components/editor/custom-plugins/LinksPlugin.tsx
@@ -1,0 +1,70 @@
+import { AutoLinkPlugin, createLinkMatcherWithRegExp } from '@lexical/react/LexicalAutoLinkPlugin';
+import { LinkPlugin as LexicalLinkPlugin } from '@lexical/react/LexicalLinkPlugin';
+import * as React from 'react';
+
+// Auto-detection patterns (stricter, used when identifying URLs in text)
+const AUTO_DETECTION_URL_REGEX =
+  /((https?:\/\/(www\.)?)|(www\.))[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)(?<![-.+():%])/;
+
+const AUTO_DETECTION_EMAIL_REGEX =
+  /(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))/;
+
+// Validation pattern (more permissive, used when checking manually entered URLs)
+const URL_VALIDATION_REGEX = /((([A-Za-z]{3,9}:(?:\/\/)?)(?:[-;:&=+$,\w]+@)?[A-Za-z0-9.-]+|(?:www.|[-;:&=+$,\w]+@)[A-Za-z0-9.-]+)((?:\/[+~%/.\w-_]*)?\??(?:[-+=&;%@.\w_]*)#?(?:[\w]*))?)/;
+
+// Set of supported URL protocols
+const SUPPORTED_URL_PROTOCOLS = new Set([
+  'http:',
+  'https:',
+  'mailto:',
+  'sms:',
+  'tel:',
+]);
+
+// Sanitize URLs to prevent security issues
+function sanitizeUrl(url: string): string {
+  try {
+    const parsedUrl = new URL(url);
+    if (!SUPPORTED_URL_PROTOCOLS.has(parsedUrl.protocol)) {
+      return 'about:blank';
+    }
+  } catch {
+    return url;
+  }
+  return url;
+}
+
+// Validate URL function
+function validateUrl(url: string): boolean {
+  const sanitizedURL = sanitizeUrl(url);
+  // Allow "https://" as it could be a user starting to type a URL
+  return sanitizedURL === 'https://' || URL_VALIDATION_REGEX.test(sanitizedURL);
+}
+
+const MATCHERS = [
+  createLinkMatcherWithRegExp(AUTO_DETECTION_URL_REGEX, (text: string) => {
+    return text.startsWith('http') ? text : `https://${text}`;
+  }),
+  createLinkMatcherWithRegExp(AUTO_DETECTION_EMAIL_REGEX, (text: string) => {
+    return `mailto:${text}`;
+  }),
+];
+
+export function LinksPlugin(): React.ReactElement {
+  return (
+    <>
+      <LexicalLinkPlugin
+        validateUrl={validateUrl}
+        attributes={{
+          rel: 'noopener',
+          target: '_blank',
+        }}
+      />
+      
+      {/* Auto-link detection */}
+      <AutoLinkPlugin matchers={MATCHERS} />
+    </>
+  );
+}
+
+export default LinksPlugin;

--- a/app/components/editor/custom-plugins/LinksPlugin.tsx
+++ b/app/components/editor/custom-plugins/LinksPlugin.tsx
@@ -1,4 +1,5 @@
 import { AutoLinkPlugin, createLinkMatcherWithRegExp } from '@lexical/react/LexicalAutoLinkPlugin';
+import { ClickableLinkPlugin } from '@lexical/react/LexicalClickableLinkPlugin';
 import { LinkPlugin as LexicalLinkPlugin } from '@lexical/react/LexicalLinkPlugin';
 import * as React from 'react';
 
@@ -63,6 +64,7 @@ export function LinksPlugin(): React.ReactElement {
       
       {/* Auto-link detection */}
       <AutoLinkPlugin matchers={MATCHERS} />
+      <ClickableLinkPlugin />
     </>
   );
 }

--- a/app/components/editor/custom-plugins/index.ts
+++ b/app/components/editor/custom-plugins/index.ts
@@ -1,4 +1,5 @@
 export { ComponentPickerPlugin } from './ComponentPickerPlugin';
+export { LinksPlugin } from './LinksPlugin';
 export { TableActionMenuPlugin } from './TableActionMenuPlugin';
 export { TableHoverActionsPlugin } from './TableHoverActionsPlugin';
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -47,6 +47,10 @@
   ); /* Placeholder text, disabled states */
   --text-disabled: rgba(var(--text-rgb), 0.3); /* Very low emphasis text */
 
+  /* Link color values */
+  --text-link: #0ea5e9; /* sky-500 color for links */
+  --text-link-hover: #38bdf8; /* sky-400 color for link hover */
+
   /* Application of core palette to specific UI elements */
   --background: var(--surface-dark);
   --foreground: var(--text);
@@ -139,6 +143,21 @@ body {
 
   .editor-placeholder {
     @apply absolute top-12 left-8 text-placeholder-text pointer-events-none select-none;
+  }
+
+  /* .editor-link {
+    @apply text-sky-500 cursor-pointer transition-colors duration-200;
+  }
+  .editor-link:hover {
+    @apply text-sky-400 underline;
+  } */
+
+  .editor-link {
+    @apply text-link cursor-pointer transition-colors duration-200;
+  }
+
+  .editor-link:hover {
+    @apply text-link-hover underline;
   }
 
   /* Node-specific styles */

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -84,6 +84,8 @@ export default {
       textColor: {
         DEFAULT: "var(--foreground)",
         "placeholder-text": "var(--placeholder-text)",
+        "link": "var(--text-link)", 
+        "link-hover": "var(--text-link-hover)", 
         "text-secondary": "var(--text-secondary)",
         "text-tertiary": "var(--text-tertiary)",
         "text-disabled": "var(--text-disabled)",


### PR DESCRIPTION
This Request: 

1. Added feature to auto-detect a link starting with http:// or https:// and other protocols
2. Auto-detect emails and create a mailto link.
3. Embed texts with links by selecting a portion of text and cmd+v/ctrl+v the link

Upcoming requests:

1. Add link to command menu dropdown
2. allow feature to edit link without deleting the text
3. add markdown support to auto convert links in this format: [example](abd.com)